### PR TITLE
Downgrade Microsoft.CodeAnalysis.CSharp.Workspaces to v3.5

### DIFF
--- a/.idea/.idea.RoslynAnalyzerTemplate/.idea/indexLayout.xml
+++ b/.idea/.idea.RoslynAnalyzerTemplate/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.RoslynAnalyzerTemplate/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.RoslynAnalyzerTemplate/.idea/projectSettingsUpdater.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RiderProjectSettingsUpdater">
+    <option name="vcsConfiguration" value="2" />
+  </component>
+</project>

--- a/.idea/.idea.RoslynAnalyzerTemplate/.idea/vcs.xml
+++ b/.idea/.idea.RoslynAnalyzerTemplate/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/RoslynAnalyzerTemplate.Test/RoslynAnalyzerTemplate.Test.csproj
+++ b/RoslynAnalyzerTemplate.Test/RoslynAnalyzerTemplate.Test.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Dena.CodeAnalysis.Testing" Version="1.0.0" />
+    <PackageReference Include="Dena.CodeAnalysis.Testing" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RoslynAnalyzerTemplate/RoslynAnalyzerTemplate.csproj
+++ b/RoslynAnalyzerTemplate/RoslynAnalyzerTemplate.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The analyzer project used by Unity is limited to Microsoft.CodeAnalysis.CSharp v3.5 in some packages.
Use them at the same time, CS8032 will occur.